### PR TITLE
Ensure test case controls the environment better, by adding a sleep

### DIFF
--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -14,14 +14,14 @@ use Illuminate\Support\Facades\Storage;
 use Watson\Validating\ValidatingTrait;
 use Illuminate\Support\Facades\Log;
 
-
 /**
  * Settings model.
  */
 class Setting extends Model
 {
     use HasFactory;
-    use Notifiable, ValidatingTrait;
+    use Notifiable;
+    use ValidatingTrait;
 
     /**
      * The cache property so that multiple invocations of this will only load the Settings record from disk only once
@@ -235,7 +235,7 @@ class Setting extends Model
         foreach ($arBytes as $arItem) {
             if ($bytes >= $arItem['VALUE']) {
                 $result = $bytes / $arItem['VALUE'];
-                $result = round($result, 2).$arItem['UNIT'];
+                $result = round($result, 2) . $arItem['UNIT'];
                 break;
             }
         }
@@ -285,14 +285,14 @@ class Setting extends Model
 
         // Check for any secure password complexity rules that may have been selected
         if ($settings->pwd_secure_complexity != '') {
-            $security_rules .= '|'.$settings->pwd_secure_complexity;
+            $security_rules .= '|' . $settings->pwd_secure_complexity;
         }
 
         if ($action == 'update') {
-            return 'nullable|min:'.$settings->pwd_secure_min.$security_rules;
+            return 'nullable|min:' . $settings->pwd_secure_min . $security_rules;
         }
 
-        return 'required|min:'.$settings->pwd_secure_min.$security_rules;
+        return 'required|min:' . $settings->pwd_secure_min . $security_rules;
     }
 
     /**
@@ -349,7 +349,7 @@ class Setting extends Model
      */
     public static function get_fresh_file_path($attribute, $path)
     {
-        $full_path = storage_path().'/'.$path;
+        $full_path = storage_path() . '/' . $path;
         $file_exists = file_exists($full_path);
         if ($file_exists) {
             $statblock = stat($full_path);
@@ -388,5 +388,4 @@ class Setting extends Model
     {
         return self::get_fresh_file_path('ldap_client_tls_key', 'ldap_client_tls.key');
     }
-
 }

--- a/tests/Unit/LdapTest.php
+++ b/tests/Unit/LdapTest.php
@@ -225,8 +225,12 @@ class LdapTest extends TestCase
     public function testFreshTLSFile()
     {
         $this->settings->enableLdap()->set(['ldap_client_tls_cert' => 'SAMPLE CERT TEXT']);
+
         $client_side_cert_path = Setting::get_client_side_cert_path();
+
+        sleep(1); // Ensure that settings vs file write time are distinct. TODO: https://github.com/hnw/php-timecop to do this properly?
         file_put_contents($client_side_cert_path, 'WEIRDLY UPDATED CERT FILE');
+
         //the system should respect our cache-file, since the settings haven't been updated
         $possibly_recached_cert_file = Setting::get_client_side_cert_path(); //this should *NOT* re-cache from the Settings
         $this->assertStringEqualsFile($possibly_recached_cert_file, 'WEIRDLY UPDATED CERT FILE');


### PR DESCRIPTION
Fix #16 ?
Not ideal; but this way
```
if (!$file_exists || Carbon::createFromTimestamp($statblock['mtime']) < Setting::getSettings()->updated_at)
```
Should never fail due to events happening in quick succession and a loss of precision happening with the comparison.