### PR TITLE
Ignore timestamp to reduce flaky test behaviour

### DIFF
--- a/tests/Feature/Importing/Api/ImportAssetModelsTest.php
+++ b/tests/Feature/Importing/Api/ImportAssetModelsTest.php
@@ -125,7 +125,8 @@ class ImportAssetModelsTest extends ImportDataTestCase implements TestsPermissio
         $updatedAssetmodel = AssetModel::query()->find($assetmodel->id);
         $updatedAttributes = [
             'name',
-            'model_number'
+            'model_number',
+            'updated_at'
         ];
 
         $this->assertEquals($row['model_number'], $updatedAssetmodel->model_number);


### PR DESCRIPTION
Fix #28 
If updated at is a few milliseconds later, the timestamp will naturally differ.